### PR TITLE
feat: 게시판 관리 기능 구현 (목록 및 상세 페이지)

### DIFF
--- a/src/app/admin/boards/[boardId]/page.tsx
+++ b/src/app/admin/boards/[boardId]/page.tsx
@@ -1,0 +1,381 @@
+'use client'
+
+import { collection, doc, getDoc, getDocs, getFirestore, query, where, Timestamp } from 'firebase/firestore'
+import { ArrowLeft, Users, Loader2, AlertCircle, RefreshCw } from 'lucide-react'
+import { 
+  Card, 
+  CardContent, 
+  CardDescription, 
+  CardHeader, 
+  CardTitle,
+  CardFooter
+} from "@/components/ui/card"
+import { Button } from "@/components/ui/button"
+import { Skeleton } from "@/components/ui/skeleton"
+import { 
+  Table, 
+  TableBody, 
+  TableCell, 
+  TableHead, 
+  TableHeader, 
+  TableRow 
+} from "@/components/ui/table"
+import { 
+  useQuery, 
+  useQueryClient 
+} from '@tanstack/react-query'
+import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert"
+import { Board, User } from '@/types/firestore'
+import { useRouter } from 'next/navigation'
+import { useParams } from 'next/navigation'
+
+// 게시판 정보 조회 함수
+const fetchBoard = async (boardId: string): Promise<Board | null> => {
+  if (!boardId) return null
+  
+  try {
+    const db = getFirestore()
+    const boardRef = doc(db, 'boards', boardId)
+    const boardDoc = await getDoc(boardRef)
+    
+    if (boardDoc.exists()) {
+      return {
+        id: boardDoc.id,
+        ...boardDoc.data()
+      } as Board
+    }
+    return null
+  } catch (error) {
+    console.error('Error fetching board:', error)
+    throw new Error('게시판 정보를 가져오는 중 오류가 발생했습니다.')
+  }
+}
+
+// 게시판 권한을 가진 사용자 목록 조회 함수
+const fetchBoardUsers = async (boardId: string): Promise<User[]> => {
+  if (!boardId) return []
+  
+  try {
+    const db = getFirestore()
+    const usersRef = collection(db, 'users')
+    const usersQuery = query(usersRef, where(`boardPermissions.${boardId}`, 'in', ['read', 'write', 'admin']))
+    const snapshot = await getDocs(usersQuery)
+    
+    return snapshot.docs.map(doc => ({
+      id: doc.id,
+      ...doc.data()
+    } as User))
+  } catch (error) {
+    console.error('Error fetching board users:', error)
+    throw new Error('게시판 사용자 정보를 가져오는 중 오류가 발생했습니다.')
+  }
+}
+
+// 권한 레벨에 따른 뱃지 스타일 반환
+const getPermissionBadge = (permission: 'read' | 'write' | 'admin') => {
+  switch (permission) {
+    case 'admin':
+      return (
+        <span className="inline-flex items-center rounded-md bg-red-50 px-2 py-1 text-xs font-medium text-red-700 ring-1 ring-inset ring-red-700/10">
+          관리자
+        </span>
+      )
+    case 'write':
+      return (
+        <span className="inline-flex items-center rounded-md bg-green-50 px-2 py-1 text-xs font-medium text-green-700 ring-1 ring-inset ring-green-700/10">
+          쓰기
+        </span>
+      )
+    case 'read':
+      return (
+        <span className="inline-flex items-center rounded-md bg-gray-50 px-2 py-1 text-xs font-medium text-gray-700 ring-1 ring-inset ring-gray-700/10">
+          읽기
+        </span>
+      )
+    default:
+      return (
+        <span className="inline-flex items-center rounded-md bg-gray-50 px-2 py-1 text-xs font-medium text-gray-500 ring-1 ring-inset ring-gray-500/10">
+          알 수 없음
+        </span>
+      )
+  }
+}
+
+export default function BoardDetailPage() {
+  const router = useRouter()
+  const params = useParams()
+  const queryClient = useQueryClient()
+  const boardId = params.boardId as string
+
+  // 게시판 정보 쿼리
+  const { 
+    data: board,
+    isLoading: boardLoading,
+    error: boardError
+  } = useQuery({
+    queryKey: ['board', boardId],
+    queryFn: () => fetchBoard(boardId),
+    enabled: !!boardId,
+    staleTime: 5 * 60 * 1000, // 5분
+  })
+
+  // 게시판 사용자 목록 쿼리
+  const { 
+    data: users = [],
+    isLoading: usersLoading,
+    error: usersError,
+    refetch: refetchUsers
+  } = useQuery({
+    queryKey: ['boardUsers', boardId],
+    queryFn: () => fetchBoardUsers(boardId),
+    enabled: !!boardId,
+    staleTime: 2 * 60 * 1000, // 2분
+  })
+
+  const handleGoBack = () => {
+    router.push('/admin/boards')
+  }
+
+  if (boardLoading) {
+    return (
+      <div className="space-y-4">
+        <Card>
+          <CardHeader>
+            <Skeleton className="h-8 w-1/3" />
+            <Skeleton className="h-4 w-1/2" />
+          </CardHeader>
+          <CardContent>
+            <div className="space-y-2">
+              {Array(3).fill(0).map((_, i) => (
+                <Skeleton key={i} className="h-12 w-full" />
+              ))}
+            </div>
+          </CardContent>
+        </Card>
+      </div>
+    )
+  }
+
+  if (boardError || !board) {
+    return (
+      <div className="space-y-4">
+        <Button
+          variant="ghost"
+          onClick={handleGoBack}
+          className="mb-4"
+        >
+          <ArrowLeft className="mr-2 h-4 w-4" />
+          게시판 목록으로 돌아가기
+        </Button>
+        
+        <Alert variant="destructive">
+          <AlertCircle className="h-4 w-4" />
+          <AlertTitle>게시판 정보를 불러올 수 없습니다</AlertTitle>
+          <AlertDescription>
+            {boardError instanceof Error ? boardError.message : '게시판이 존재하지 않거나 접근할 수 없습니다.'}
+          </AlertDescription>
+          <div className="mt-4">
+            <Button 
+              variant="outline" 
+              onClick={() => queryClient.invalidateQueries({ queryKey: ['board', boardId] })}
+            >
+              <RefreshCw className="mr-2 h-4 w-4" />
+              다시 시도
+            </Button>
+          </div>
+        </Alert>
+      </div>
+    )
+  }
+
+  const firstDay = board.firstDay 
+    ? (board.firstDay instanceof Timestamp 
+        ? board.firstDay.toDate() 
+        : new Date(board.firstDay))
+    : null
+
+  const createdAt = board.createdAt 
+    ? (board.createdAt instanceof Timestamp 
+        ? board.createdAt.toDate() 
+        : new Date(board.createdAt))
+    : null
+
+  return (
+    <div className="space-y-6">
+      <div className="flex items-center gap-4">
+        <Button
+          variant="ghost"
+          onClick={handleGoBack}
+        >
+          <ArrowLeft className="mr-2 h-4 w-4" />
+          게시판 목록으로 돌아가기
+        </Button>
+      </div>
+
+      <div>
+        <h1 className="text-3xl font-bold tracking-tight">{board.title}</h1>
+        <p className="text-muted-foreground">
+          게시판 상세 정보 및 사용자 권한을 확인합니다.
+        </p>
+      </div>
+
+      {/* 게시판 정보 카드 */}
+      <Card>
+        <CardHeader>
+          <CardTitle>게시판 정보</CardTitle>
+        </CardHeader>
+        <CardContent className="space-y-4">
+          <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+            <div>
+              <label className="text-sm font-medium text-muted-foreground">제목</label>
+              <div className="mt-1 text-sm">{board.title}</div>
+            </div>
+            
+            <div>
+              <label className="text-sm font-medium text-muted-foreground">코호트</label>
+              <div className="mt-1">
+                {board.cohort ? (
+                  <span className="inline-flex items-center rounded-md bg-blue-50 px-2 py-1 text-xs font-medium text-blue-700 ring-1 ring-inset ring-blue-700/10">
+                    {board.cohort}
+                  </span>
+                ) : (
+                  <span className="text-gray-400">설정되지 않음</span>
+                )}
+              </div>
+            </div>
+            
+            <div>
+              <label className="text-sm font-medium text-muted-foreground">시작일</label>
+              <div className="mt-1 text-sm">
+                {firstDay ? (
+                  <div>
+                    {firstDay.toLocaleDateString('ko-KR')} ({firstDay.toLocaleDateString('ko-KR', { weekday: 'short' })})
+                  </div>
+                ) : (
+                  <span className="text-gray-400">설정되지 않음</span>
+                )}
+              </div>
+            </div>
+            
+            <div>
+              <label className="text-sm font-medium text-muted-foreground">생성일</label>
+              <div className="mt-1 text-sm">
+                {createdAt ? (
+                  createdAt.toLocaleDateString('ko-KR')
+                ) : (
+                  <span className="text-gray-400">알 수 없음</span>
+                )}
+              </div>
+            </div>
+          </div>
+          
+          <div>
+            <label className="text-sm font-medium text-muted-foreground">설명</label>
+            <div className="mt-1 text-sm">
+              {board.description || '설명이 없습니다.'}
+            </div>
+          </div>
+          
+          <div>
+            <label className="text-sm font-medium text-muted-foreground">대기 중인 사용자</label>
+            <div className="mt-1 text-sm">
+              {board.waitingUsersIds && board.waitingUsersIds.length > 0 ? (
+                <span className="text-orange-600">{board.waitingUsersIds.length}명 대기 중</span>
+              ) : (
+                <span className="text-green-600">대기 중인 사용자 없음</span>
+              )}
+            </div>
+          </div>
+        </CardContent>
+      </Card>
+
+      {/* 사용자 권한 목록 카드 */}
+      <Card>
+        <CardHeader>
+          <div className="flex justify-between items-center">
+            <div>
+              <CardTitle>
+                사용자 권한 목록
+                <span className="ml-2 text-muted-foreground font-normal text-sm">
+                  ({users.length}명)
+                </span>
+              </CardTitle>
+              <CardDescription>
+                이 게시판에 접근 권한을 가진 사용자 목록입니다.
+              </CardDescription>
+            </div>
+            {usersError && (
+              <Button 
+                variant="outline" 
+                size="sm"
+                onClick={() => refetchUsers()}
+              >
+                <RefreshCw className="mr-2 h-4 w-4" />
+                새로고침
+              </Button>
+            )}
+          </div>
+        </CardHeader>
+        <CardContent className="overflow-x-auto">
+          {usersLoading ? (
+            <div className="flex items-center justify-center py-8">
+              <Loader2 className="h-8 w-8 animate-spin text-muted-foreground" />
+              <span className="ml-2 text-muted-foreground">사용자 정보를 불러오는 중...</span>
+            </div>
+          ) : usersError ? (
+            <Alert variant="destructive" className="my-4">
+              <AlertCircle className="h-4 w-4" />
+              <AlertTitle>사용자 정보를 불러올 수 없습니다</AlertTitle>
+              <AlertDescription>
+                {usersError instanceof Error ? usersError.message : '사용자 권한 정보를 가져오는 중 오류가 발생했습니다.'}
+              </AlertDescription>
+            </Alert>
+          ) : users.length === 0 ? (
+            <div className="text-center py-8 text-muted-foreground">
+              <Users className="h-12 w-12 mx-auto mb-3 text-muted-foreground/50" />
+              <p>이 게시판에 권한을 가진 사용자가 없습니다.</p>
+            </div>
+          ) : (
+            <Table>
+              <TableHeader>
+                <TableRow>
+                  <TableHead>닉네임</TableHead>
+                  <TableHead>실명</TableHead>
+                  <TableHead>이메일</TableHead>
+                  <TableHead className="text-center">권한</TableHead>
+                </TableRow>
+              </TableHeader>
+              <TableBody>
+                {users.map((user) => {
+                  const permission = user.boardPermissions[boardId] as 'read' | 'write' | 'admin'
+                  
+                  return (
+                    <TableRow key={user.id}>
+                      <TableCell className="font-medium">
+                        {user.nickname || '닉네임 없음'}
+                      </TableCell>
+                      <TableCell>
+                        {user.realName || '실명 없음'}
+                      </TableCell>
+                      <TableCell>
+                        {user.email || '이메일 없음'}
+                      </TableCell>
+                      <TableCell className="text-center">
+                        {getPermissionBadge(permission)}
+                      </TableCell>
+                    </TableRow>
+                  )
+                })}
+              </TableBody>
+            </Table>
+          )}
+        </CardContent>
+        <CardFooter className="border-t px-6 py-3">
+          <div className="text-xs text-muted-foreground">
+            마지막 업데이트: {new Date().toLocaleString('ko-KR')}
+          </div>
+        </CardFooter>
+      </Card>
+    </div>
+  )
+}

--- a/src/app/admin/boards/page.tsx
+++ b/src/app/admin/boards/page.tsx
@@ -1,20 +1,225 @@
 'use client'
 
-import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card"
+import { collection, getDocs, getFirestore, Timestamp } from 'firebase/firestore'
+import { Eye, AlertCircle, RefreshCw, Newspaper } from 'lucide-react'
+import { 
+  Card, 
+  CardContent, 
+  CardDescription, 
+  CardHeader, 
+  CardTitle,
+  CardFooter
+} from "@/components/ui/card"
+import { Button } from "@/components/ui/button"
+import { Skeleton } from "@/components/ui/skeleton"
+import { 
+  Table, 
+  TableBody, 
+  TableCell, 
+  TableHead, 
+  TableHeader, 
+  TableRow 
+} from "@/components/ui/table"
+import { 
+  useQuery, 
+  useQueryClient 
+} from '@tanstack/react-query'
+import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert"
+import { Board } from '@/types/firestore'
+import { useRouter } from 'next/navigation'
+
+// 게시판 목록 조회 함수
+const fetchBoards = async (): Promise<Board[]> => {
+  try {
+    const db = getFirestore()
+    const boardsRef = collection(db, 'boards')
+    const snapshot = await getDocs(boardsRef)
+    
+    const boards = snapshot.docs.map(doc => ({
+      id: doc.id,
+      ...doc.data()
+    } as Board))
+    
+    // 코호트 번호 기준 내림차순 정렬 (높은 번호 -> 낮은 번호)
+    return boards.sort((a, b) => {
+      const cohortA = a.cohort || 0
+      const cohortB = b.cohort || 0
+      return cohortB - cohortA
+    })
+  } catch (error) {
+    console.error('Error fetching boards:', error)
+    throw new Error('게시판 목록을 가져오는 중 오류가 발생했습니다.')
+  }
+}
 
 export default function BoardsPage() {
+  const router = useRouter()
+  const queryClient = useQueryClient()
+
+  // 게시판 목록 쿼리
+  const { 
+    data: boards = [], 
+    isLoading: boardsLoading, 
+    error: boardsError 
+  } = useQuery({
+    queryKey: ['boards'],
+    queryFn: fetchBoards,
+    staleTime: 5 * 60 * 1000, // 5분
+  })
+
+  // 게시판 상세 페이지로 이동
+  const handleViewBoard = (boardId: string) => {
+    router.push(`/admin/boards/${boardId}`)
+  }
+
+  if (boardsLoading) {
+    return (
+      <div className="space-y-4">
+        <Card>
+          <CardHeader>
+            <Skeleton className="h-8 w-1/3" />
+            <Skeleton className="h-4 w-1/2" />
+          </CardHeader>
+          <CardContent>
+            <div className="space-y-2">
+              {Array(5).fill(0).map((_, i) => (
+                <Skeleton key={i} className="h-12 w-full" />
+              ))}
+            </div>
+          </CardContent>
+        </Card>
+      </div>
+    )
+  }
+
+  if (boardsError) {
+    return (
+      <Alert variant="destructive" className="mb-4">
+        <AlertCircle className="h-4 w-4" />
+        <AlertTitle>게시판 목록을 불러올 수 없습니다</AlertTitle>
+        <AlertDescription>
+          {boardsError instanceof Error ? boardsError.message : '서버 오류가 발생했습니다. 나중에 다시 시도해주세요.'}
+        </AlertDescription>
+        <div className="mt-4">
+          <Button 
+            variant="outline" 
+            onClick={() => queryClient.invalidateQueries({ queryKey: ['boards'] })}
+          >
+            <RefreshCw className="mr-2 h-4 w-4" />
+            다시 시도
+          </Button>
+        </div>
+      </Alert>
+    )
+  }
+
   return (
-    <div>
+    <div className="space-y-6">
+      <div>
+        <h1 className="text-3xl font-bold tracking-tight">게시판 관리</h1>
+        <p className="text-muted-foreground">
+          모든 게시판을 조회하고 관리합니다.
+        </p>
+      </div>
+
       <Card>
         <CardHeader>
-          <CardTitle>게시판 관리</CardTitle>
-          <CardDescription>
-            게시판을 생성, 수정, 삭제하고 권한을 관리합니다.
-          </CardDescription>
+          <div className="flex justify-between items-center">
+            <div>
+              <CardTitle>
+                게시판 목록
+                <span className="ml-2 text-muted-foreground font-normal text-sm">
+                  ({boards.length}개)
+                </span>
+              </CardTitle>
+              <CardDescription>
+                코호트별로 정렬된 게시판 목록입니다.
+              </CardDescription>
+            </div>
+          </div>
         </CardHeader>
-        <CardContent>
-          <p>게시판 관리 기능이 여기에 구현될 예정입니다.</p>
+        <CardContent className="overflow-x-auto">
+          {boards.length === 0 ? (
+            <div className="text-center py-8 text-muted-foreground">
+              <Newspaper className="h-12 w-12 mx-auto mb-3 text-muted-foreground/50" />
+              <p>등록된 게시판이 없습니다.</p>
+            </div>
+          ) : (
+            <Table>
+              <TableHeader>
+                <TableRow>
+                  <TableHead className="w-[80px]">코호트</TableHead>
+                  <TableHead>제목</TableHead>
+                  <TableHead>설명</TableHead>
+                  <TableHead>시작일</TableHead>
+                  <TableHead className="text-right">작업</TableHead>
+                </TableRow>
+              </TableHeader>
+              <TableBody>
+                {boards.map((board) => {
+                  const firstDay = board.firstDay 
+                    ? (board.firstDay instanceof Timestamp 
+                        ? board.firstDay.toDate() 
+                        : new Date(board.firstDay))
+                    : null
+                  
+                  return (
+                    <TableRow key={board.id}>
+                      <TableCell className="font-medium text-center">
+                        {board.cohort ? (
+                          <span className="inline-flex items-center rounded-md bg-blue-50 px-2 py-1 text-xs font-medium text-blue-700 ring-1 ring-inset ring-blue-700/10">
+                            {board.cohort}
+                          </span>
+                        ) : (
+                          <span className="text-gray-400">-</span>
+                        )}
+                      </TableCell>
+                      <TableCell className="font-medium">
+                        {board.title}
+                      </TableCell>
+                      <TableCell className="max-w-[300px]">
+                        <div className="truncate text-muted-foreground">
+                          {board.description || '설명 없음'}
+                        </div>
+                      </TableCell>
+                      <TableCell>
+                        {firstDay ? (
+                          <div>
+                            <div className="text-sm">
+                              {firstDay.toLocaleDateString('ko-KR')}
+                            </div>
+                            <div className="text-xs text-muted-foreground">
+                              {firstDay.toLocaleDateString('ko-KR', { 
+                                weekday: 'short'
+                              })}
+                            </div>
+                          </div>
+                        ) : (
+                          <span className="text-gray-400">날짜 없음</span>
+                        )}
+                      </TableCell>
+                      <TableCell className="text-right">
+                        <Button
+                          size="sm"
+                          variant="outline"
+                          onClick={() => handleViewBoard(board.id)}
+                        >
+                          <Eye className="h-4 w-4 mr-1" />
+                          상세보기
+                        </Button>
+                      </TableCell>
+                    </TableRow>
+                  )
+                })}
+              </TableBody>
+            </Table>
+          )}
         </CardContent>
+        <CardFooter className="border-t px-6 py-3">
+          <div className="text-xs text-muted-foreground">
+            마지막 업데이트: {new Date().toLocaleString('ko-KR')}
+          </div>
+        </CardFooter>
       </Card>
     </div>
   )


### PR DESCRIPTION
## 요약
- 게시판 목록 및 상세보기 기능을 포함한 종합적인 게시판 관리 기능 추가
- 코호트 기준 정렬과 네비게이션이 포함된 게시판 목록 구현
- 사용자 권한을 표시하는 게시판 상세 페이지 생성 (조회 전용)

## 주요 기능
- **게시판 목록 페이지**: 코호트, 제목, 설명, 시작일을 표시하는 테이블 (코호트 내림차순 정렬)
- **게시판 상세 페이지**: 사용자 권한 테이블과 함께 완전한 게시판 정보 표시
- **사용자 권한 표시**: 닉네임, 실명, 이메일, 권한 레벨 표시 (읽기/쓰기/관리자)
- **반응형 디자인**: 기존 관리자 UI 패턴 준수
- **에러 처리**: 적절한 로딩 상태 및 에러 경계 처리

## 기술적 구현
- 데이터 페칭 및 캐싱을 위한 React Query 사용
- [boardId] 매개변수를 사용한 동적 라우팅
- 게시판 및 사용자 데이터를 위한 Firestore 쿼리
- 기존 관리자 페이지(사용자 승인, 게시물)와 일관성 유지

## 테스트 계획
- [ ] /admin/boards로 이동하여 게시판 목록이 올바르게 표시되는지 확인
- [ ] 게시판이 코호트 번호 기준 내림차순으로 정렬되는지 확인
- [ ] "상세보기" 버튼 클릭으로 게시판 상세 페이지 접근 확인
- [ ] 상세 페이지에서 게시판 정보가 올바르게 표시되는지 확인
- [ ] 사용자 권한 테이블이 게시판 접근 권한을 가진 모든 사용자를 표시하는지 확인
- [ ] 게시판 목록으로의 뒤로가기 네비게이션 테스트
- [ ] 모바일 기기에서 반응형 디자인 확인

🤖 Generated with [Claude Code](https://claude.ai/code)