### PR TITLE
feat: Add force refresh mechanism for Remote Config

### DIFF
--- a/src/lib/firebase.ts
+++ b/src/lib/firebase.ts
@@ -22,9 +22,10 @@ export const storage = getStorage(app)
 // Initialize Remote Config
 export const remoteConfig = getRemoteConfig(app)
 
-// Set minimum fetch interval (1 minute for development, 12 hours for production)
-remoteConfig.settings.minimumFetchIntervalMillis = 
-  process.env.NODE_ENV === 'development' ? 60000 : 43200000
+// Set minimum fetch interval (10 seconds for development, 1 minute for production)
+// This allows more frequent updates when remote config values change
+remoteConfig.settings.minimumFetchIntervalMillis =
+  process.env.NODE_ENV === 'development' ? 10000 : 60000
 
 // Set default values
 remoteConfig.defaultConfig = {


### PR DESCRIPTION
## Summary
- Implemented force refresh mechanism to ensure Remote Config values are always up-to-date
- Added manual refresh button with loading state
- Ensured latest values are fetched before editing and saving board configurations

## Changes
### 1. Remote Config Hook Improvements (`src/hooks/useRemoteConfig.ts`)
- Added `forceRefresh` function that temporarily sets minimum fetch interval to 0 for immediate updates
- Reduced cache intervals: 30 seconds stale time, auto-refetch every 30 seconds
- Added `isRefreshing` state to track refresh operations

### 2. Firebase Config Updates (`src/lib/firebase.ts`)
- Reduced `minimumFetchIntervalMillis` to 10 seconds for development, 1 minute for production
- Allows more frequent updates when remote config values change

### 3. UI Enhancements (`src/app/admin/boards/page.tsx`)
- Added refresh button with spinning animation
- Force refresh before entering edit mode to ensure editing latest values
- Force refresh before saving to prevent overwriting concurrent changes
- Refresh after successful save to display latest server values
- Improved loading states and button disable logic during refresh

## Test Plan
- [x] Verify refresh button fetches latest Remote Config values
- [x] Confirm edit mode loads latest values before allowing changes
- [x] Test that save operation refreshes before and after updating
- [x] Check loading states display correctly during refresh operations
- [x] Ensure build passes without errors

🤖 Generated with [Claude Code](https://claude.ai/code)